### PR TITLE
use shiki-renderer-hast

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "yarn": "1.x"
   },
   "dependencies": {
-    "hast-util-raw": "^7.1.1",
     "hast-util-to-string": "^2.0.0",
+    "shiki-renderer-hast": "^1.0.0",
     "unified": "^10.1.0",
     "unist-util-visit": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "hast-util-to-string": "^2.0.0",
-    "shiki-renderer-hast": "^1.0.1",
+    "shiki-renderer-hast": "^1.0.2",
     "unified": "^10.1.0",
     "unist-util-visit": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "hast-util-to-string": "^2.0.0",
-    "shiki-renderer-hast": "^1.0.2",
+    "shiki-renderer-hast": "^1.0.3",
     "unified": "^10.1.0",
     "unist-util-visit": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "hast-util-to-string": "^2.0.0",
-    "shiki-renderer-hast": "^1.0.0",
+    "shiki-renderer-hast": "^1.0.1",
     "unified": "^10.1.0",
     "unist-util-visit": "^4.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import { raw as parse } from 'hast-util-raw'
 import { toString } from 'hast-util-to-string'
+import { codeToHast } from 'shiki-renderer-hast'
 import { visit } from 'unist-util-visit'
 
 /**
@@ -27,14 +27,7 @@ function attacher(options) {
         lang = null
       }
 
-      /**
-       * There probably is a better way than parsing the html string returned by shiki.
-       * E.g. generate hast with `hastscript` from tokens returned by `highlighter.codeToThemedTokens`.
-       */
-      const code = parse({
-        type: 'raw',
-        value: highlighter.codeToHtml(toString(node), lang),
-      })
+      const code = codeToHast(highlighter, toString(node), lang)
 
       parent.properties = code.properties
       parent.children = code.children

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,14 +37,12 @@ it('highlights code block in html', async () => {
   const vfile = await processor.process(fixtures.known)
 
   expect(String(vfile)).toMatchInlineSnapshot(`
-    "<h1>Heading</h1>
-    <p>Text</p>
-    <pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"></span>
-    <span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">    </span><span style=\\"color: #81A1C1\\">const</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #D8DEE9\\">hello</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #A3BE8C\\">World</span><span style=\\"color: #ECEFF4\\">\\"</span></span>
-    <span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">  </span></span></code></pre>
-    <p>More text</p>
-    "
-  `)
+"<h1>Heading</h1>
+<p>Text</p>
+<pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"></span><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">    </span><span style=\\"color: #81A1C1\\">const</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #D8DEE9\\">hello</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #A3BE8C\\">World</span><span style=\\"color: #ECEFF4\\">\\"</span></span><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">  </span></span></code></pre>
+<p>More text</p>
+"
+`)
 })
 
 it('highlights code block in html when running synchronously', async () => {
@@ -53,14 +51,12 @@ it('highlights code block in html when running synchronously', async () => {
   const vfile = processor.processSync(fixtures.known)
 
   expect(String(vfile)).toMatchInlineSnapshot(`
-    "<h1>Heading</h1>
-    <p>Text</p>
-    <pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"></span>
-    <span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">    </span><span style=\\"color: #81A1C1\\">const</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #D8DEE9\\">hello</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #A3BE8C\\">World</span><span style=\\"color: #ECEFF4\\">\\"</span></span>
-    <span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">  </span></span></code></pre>
-    <p>More text</p>
-    "
-  `)
+"<h1>Heading</h1>
+<p>Text</p>
+<pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"></span><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">    </span><span style=\\"color: #81A1C1\\">const</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #D8DEE9\\">hello</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #81A1C1\\">=</span><span style=\\"color: #D8DEE9FF\\"> </span><span style=\\"color: #ECEFF4\\">\\"</span><span style=\\"color: #A3BE8C\\">World</span><span style=\\"color: #ECEFF4\\">\\"</span></span><span class=\\"line\\"><span style=\\"color: #D8DEE9FF\\">  </span></span></code></pre>
+<p>More text</p>
+"
+`)
 })
 
 it('ignores code block without language', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,10 +3969,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki-renderer-hast@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.1.tgz#3678c2eb77a7caa01de357bd4fc838622eedf2af"
-  integrity sha512-UY8QCT0Fr2FFxewcUIfmj+K0oSyeZ0FT4Bxj4w8EVSxGBW4EvGbdpn6Ec7TVVwiH5YdQxGsxC+eRhqH/jUfumg==
+shiki-renderer-hast@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.2.tgz#6ad5c759461826ff654bc7f33409af4fd4f83e01"
+  integrity sha512-ZaL3yayK1eSVWlpk/KOGk8QnRvSVF1xveKXOb2/k03Qh/66EuVRiDoos3tr2fGpKXPL/lhk0XNM1Yhk7Kv6kCQ==
   dependencies:
     hastscript "^7.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,10 +3969,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki-renderer-hast@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.2.tgz#6ad5c759461826ff654bc7f33409af4fd4f83e01"
-  integrity sha512-ZaL3yayK1eSVWlpk/KOGk8QnRvSVF1xveKXOb2/k03Qh/66EuVRiDoos3tr2fGpKXPL/lhk0XNM1Yhk7Kv6kCQ==
+shiki-renderer-hast@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.3.tgz#be1374c04907c33deae4b51eb8e7edec4eac2a78"
+  integrity sha512-uX/qavXvB65xONsC8BJYpZIJzJjKoa+nYcMqVq8oJp4dPVbP5dvb69yPLuCBmkj4xUAOk+zOegEqxzoPvvJiZQ==
   dependencies:
     hastscript "^7.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,19 +2196,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hast-to-hyperscript@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-10.0.1.tgz#3decd7cb4654bca8883f6fcbd4fb3695628c4296"
-  integrity sha512-dhIVGoKCQVewFi+vz3Vt567E4ejMppS1haBRL6TEmeLeJVB1i/FJIIg/e6s1Bwn0g5qtYojHEKvyGA+OZuyifw==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    comma-separated-tokens "^2.0.0"
-    property-information "^6.0.0"
-    space-separated-tokens "^2.0.0"
-    style-to-object "^0.3.0"
-    unist-util-is "^5.0.0"
-    web-namespaces "^2.0.0"
-
 hast-util-from-parse5@^7.0.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.0.tgz#c129dd3a24dd8a867ab8a029ca47e27aa54864b7"
@@ -2238,23 +2225,6 @@ hast-util-parse-selector@^3.0.0:
   dependencies:
     "@types/hast" "^2.0.0"
 
-hast-util-raw@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.0.tgz#279fe5bc154f1c0b956f656781fa9ae1fdac7c70"
-  integrity sha512-K2ofsY59XqrtBNUAkvT2vPdyNPUchjj1Z0FxUOwBadS6R5h9O3LaRZqpukQ+YfgQ/IMy9GGMB/Nlpzpu+cuuMA==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    "@types/parse5" "^6.0.0"
-    hast-util-from-parse5 "^7.0.0"
-    hast-util-to-parse5 "^7.0.0"
-    html-void-elements "^2.0.0"
-    parse5 "^6.0.0"
-    unist-util-position "^4.0.0"
-    unist-util-visit "^4.0.0"
-    vfile "^5.0.0"
-    web-namespaces "^2.0.0"
-    zwitch "^2.0.0"
-
 hast-util-to-html@^8.0.0:
   version "8.0.2"
   resolved "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.2.tgz#3445497508e2157a3169864eb43fb6ee929d3cbe"
@@ -2271,18 +2241,6 @@ hast-util-to-html@^8.0.0:
     stringify-entities "^4.0.0"
     unist-util-is "^5.0.0"
 
-hast-util-to-parse5@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.0.0.tgz#a39808e69005d10afeed1866029a1fb137df3f7c"
-  integrity sha512-YHiS6aTaZ3N0Q3nxaY/Tj98D6kM8QX5Q8xqgg8G45zR7PvWnPGPP0vcKCgb/moIydEJ/QWczVrX0JODCVeoV7A==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    "@types/parse5" "^6.0.0"
-    hast-to-hyperscript "^10.0.0"
-    property-information "^6.0.0"
-    web-namespaces "^2.0.0"
-    zwitch "^2.0.0"
-
 hast-util-to-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz#b008b0a4ea472bf34dd390b7eea1018726ae152a"
@@ -2295,7 +2253,7 @@ hast-util-whitespace@^2.0.0:
   resolved "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz#4fc1086467cc1ef5ba20673cb6b03cec3a970f1c"
   integrity sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==
 
-hastscript@^7.0.0:
+hastscript@^7.0.0, hastscript@^7.0.2:
   version "7.0.2"
   resolved "https://registry.npmjs.org/hastscript/-/hastscript-7.0.2.tgz#d811fc040817d91923448a28156463b2e40d590a"
   integrity sha512-uA8ooUY4ipaBvKcMuPehTAB/YfFLSSzCwFSwT6ltJbocFUKH/GDHLN+tflq7lSRf9H86uOuxOFkh1KgIy3Gg2g==
@@ -2417,11 +2375,6 @@ ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
-inline-style-parser@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
-  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -4016,6 +3969,13 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki-renderer-hast@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.0.tgz#e6e8dd98ea5db6a0dd1c00d38ee6628af25b1152"
+  integrity sha512-Eo5M1WlJ4Oul1B8GLzjy8rrQE1Tn8PZb1xhZJEY151KqP8x41zSARCGAElG8XNxTwzbE1Z5UGTgfwgZufQwbrA==
+  dependencies:
+    hastscript "^7.0.2"
+
 shiki@^0.9.6:
   version "0.9.9"
   resolved "https://registry.npmjs.org/shiki/-/shiki-0.9.9.tgz#8e8f506408c8259a4b82322d09c1ce702cd498d9"
@@ -4240,13 +4200,6 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-style-to-object@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
-  integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
-  dependencies:
-    inline-style-parser "0.1.1"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -4491,11 +4444,6 @@ unist-util-is@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
-
-unist-util-position@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.1.tgz#f8484b2da19a897a0180556d160c28633070dbb9"
-  integrity sha512-mgy/zI9fQ2HlbOtTdr2w9lhVaiFUHWQnZrFF2EUoVOqtAUdzqMtNiD99qA5a1IcjWVR8O6aVYE9u7Z2z1v0SQA==
 
 unist-util-stringify-position@^3.0.0:
   version "3.0.0"
@@ -4779,8 +4727,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zwitch@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz#91f8d0e901ffa3d66599756dde7f57b17c95dce1"
-  integrity sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,10 +3969,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki-renderer-hast@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.0.tgz#e6e8dd98ea5db6a0dd1c00d38ee6628af25b1152"
-  integrity sha512-Eo5M1WlJ4Oul1B8GLzjy8rrQE1Tn8PZb1xhZJEY151KqP8x41zSARCGAElG8XNxTwzbE1Z5UGTgfwgZufQwbrA==
+shiki-renderer-hast@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/shiki-renderer-hast/-/shiki-renderer-hast-1.0.1.tgz#3678c2eb77a7caa01de357bd4fc838622eedf2af"
+  integrity sha512-UY8QCT0Fr2FFxewcUIfmj+K0oSyeZ0FT4Bxj4w8EVSxGBW4EvGbdpn6Ec7TVVwiH5YdQxGsxC+eRhqH/jUfumg==
   dependencies:
     hastscript "^7.0.2"
 


### PR DESCRIPTION
Use [`shiki-renderer-hast`](https://github.com/sachinraja/shiki-renderer-hast) instead of getting HTML with `highlighter.codeToHtml` and parsing it. Had to update the snapshots because there were some whitespace differences.